### PR TITLE
feat: Update admin access and add homepage link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 // src/app/page.tsx
 'use client'; // Needs to be client component for useState
 import { useState } from 'react';
+import Link from 'next/link'; // Make sure Link is imported
 import QuestionList from '@/components/QuestionList';
 import QuestionSubmitButton from '@/components/QuestionSubmitButton';
 
@@ -32,6 +33,16 @@ export default function HomePage() {
       </div>
 
       <QuestionList selectedCategory={selectedCategory} />
-    </div>
+
+      {/* Add the new button here */}
+      <div className="mt-12 text-center">
+        <Link
+          href="/admin"
+          className="bg-gray-700 hover:bg-gray-900 text-white font-semibold py-2 px-4 rounded-lg shadow transition-colors duration-150 ease-in-out"
+        >
+          ヘポたま専用ボタン
+        </Link>
+      </div>
+    </div> // This is the closing tag of the main container div
   );
 }

--- a/src/components/AdminAuth.tsx
+++ b/src/components/AdminAuth.tsx
@@ -12,7 +12,7 @@ export default function AdminAuth({ onAuthenticated }: AdminAuthProps) {
 
   // In a real app, this would be an environment variable and checked on the backend.
   // For this MVP, we'll do a simple client-side check.
-  const ADMIN_PASSWORD = process.env.NEXT_PUBLIC_ADMIN_PASSWORD || 'password'; // Fallback for local dev
+  const ADMIN_PASSWORD = process.env.NEXT_PUBLIC_ADMIN_PASSWORD || '8888'; // Fallback for local dev
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -51,7 +51,7 @@ export default function AdminAuth({ onAuthenticated }: AdminAuthProps) {
           ログイン
         </button>
       </form>
-       <p className="text-xs text-gray-500 mt-4">開発用: 環境変数 `NEXT_PUBLIC_ADMIN_PASSWORD` でパスワードを設定できます。デフォルトは "password" です。</p>
+       <p className="text-xs text-gray-500 mt-4">開発用: 環境変数 `NEXT_PUBLIC_ADMIN_PASSWORD` でパスワードを設定できます。デフォルトは "8888" です。</p>
     </div>
   );
 }


### PR DESCRIPTION
This commit implements your requested changes to admin functionality:

1.  **Admin Password Update:**
    *   The fallback admin password in `AdminAuth.tsx` has been changed to "8888" as per your request.
    *   The descriptive help text for the default password in the AdminAuth component has also been updated to reflect this change.

2.  **Homepage Admin Link:**
    *   Added a button labeled "ヘポたま専用ボタン" (Hepokutama Exclusive Button) to the bottom of the homepage (`page.tsx`).
    *   This button provides a direct link to the admin login page (`/admin`).