### PR TITLE
Fix: Correct question submission token logic and enable cascade deletes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Question {
 
 model Answer {
   id          Int      @id @default(autoincrement())
-  question    Question @relation(fields: [question_id], references: [id])
+  question    Question @relation(fields: [question_id], references: [id], onDelete: Cascade)
   question_id Int
   content     String
   image_url   String?  @db.VarChar(500)
@@ -47,7 +47,7 @@ model Answer {
 
 model Like {
   id          Int      @id @default(autoincrement())
-  question    Question @relation(fields: [question_id], references: [id])
+  question    Question @relation(fields: [question_id], references: [id], onDelete: Cascade)
   question_id Int
   ip_address  String?  @db.Inet // Prisma doesn't have Inet, use String and handle validation at app level or use native type if possible later
   created_at  DateTime @default(now())
@@ -57,7 +57,7 @@ model Like {
 
 model Comment {
   id             Int      @id @default(autoincrement())
-  question       Question @relation(fields: [question_id], references: [id])
+  question       Question @relation(fields: [question_id], references: [id], onDelete: Cascade)
   question_id    Int
   content        String
   commenter_name String   @default("匿名") @db.VarChar(50)

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -29,10 +29,8 @@ export default function SubmitPage() {
       return;
     }
     setIsSubmitting(true);
-    const currentToken = notificationToken || generateToken();
-    if (!notificationToken) {
-        setNotificationToken(currentToken); // Set it if it was just generated
-    }
+    const currentToken = generateToken(); // Always generate a new token for each submission
+    setNotificationToken(currentToken); // Update state for this submission instance (optional, as it's used immediately)
 
     try {
       const response = await fetch('/api/questions', {
@@ -65,6 +63,7 @@ export default function SubmitPage() {
       setContent('');
       setCategory('');
       setSubmitterNickname('');
+      setNotificationToken(''); // Reset for the next submission
       // Optional: Redirect after a delay or provide a link to the question
       // router.push(`/question/${newQuestion.id}`);
     } catch (err: any) {


### PR DESCRIPTION
This commit addresses two critical issues:

1.  Fixes question submission failures caused by non-unique `notification_token`.
    - Modified `src/app/submit/page.tsx` to ensure a new, unique `notification_token` is generated for every submission attempt.
    - The `notificationToken` state is also cleared after a successful submission.
    - This prevents unique constraint errors in the database when you submit multiple questions without refreshing the page.

2.  Fixes errors when deleting questions that have related records.
    - Updated `prisma/schema.prisma` to add `onDelete: Cascade` to the relations in the `Answer`, `Like`, and `Comment` models that link to the `Question` model.
    - This ensures that when a question is deleted, all its associated answers, likes, and comments are also automatically deleted by the database.
    - **Note**: The corresponding Prisma migration (`npx prisma migrate dev`) needs to be generated and applied in the deployment environment for these schema changes to take effect.

All existing unit tests were reviewed and confirmed to pass with these changes.