### PR TITLE
feat: Add "Nanno Jikan Dayo" button and update home page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7985,6 +7985,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Question {
   answers            Answer[]
   likes              Like[]
   comments           Comment[]
+  nannoJikanDayoCount Int @default(0)
 
   @@index([status])
   @@index([category])

--- a/src/app/api/questions/[id]/nannojikandayo/route.ts
+++ b/src/app/api/questions/[id]/nannojikandayo/route.ts
@@ -1,0 +1,86 @@
+// src/app/api/questions/[id]/nannojikandayo/route.ts
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { getClientIp } from 'request-ip'; // May need to install request-ip: npm install request-ip @types/request-ip
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const questionId = parseInt(params.id, 10);
+  const clientIp = getClientIp(request);
+
+  if (isNaN(questionId)) {
+    return NextResponse.json({ error: 'Invalid question ID' }, { status: 400 });
+  }
+
+  try {
+    // Conceptual: Check if this IP has already clicked this button for this question
+    // This requires the NannoJikanDayoClick model in the schema and a migration.
+    // For now, we'll simulate this check. If the model existed, it would be:
+    /*
+    if (clientIp) {
+      const existingClick = await prisma.nannoJikanDayoClick.findUnique({
+        where: {
+          question_id_ip_address: { // This compound key name is Prisma's default
+            question_id: questionId,
+            ip_address: clientIp,
+          },
+        },
+      });
+
+      if (existingClick) {
+        // Fetch the current count without incrementing if already clicked
+        const question = await prisma.question.findUnique({
+          where: { id: questionId },
+          select: { nannoJikanDayoCount: true },
+        });
+        return NextResponse.json({
+          message: 'You have already clicked this today for this question.',
+          nannoJikanDayoCount: question?.nannoJikanDayoCount ?? 0,
+        }, { status: 403 }); // Forbidden or a custom status
+      }
+    }
+    */
+
+    // If the NannoJikanDayoClick model and migration were applied:
+    // 1. Create the click record
+    /*
+    if (clientIp) {
+      await prisma.nannoJikanDayoClick.create({
+        data: {
+          question_id: questionId,
+          ip_address: clientIp,
+        },
+      });
+    }
+    */
+
+    // 2. Increment the count
+    const updatedQuestion = await prisma.question.update({
+      where: { id: questionId },
+      data: {
+        nannoJikanDayoCount: {
+          increment: 1,
+        },
+      },
+      select: {
+        nannoJikanDayoCount: true,
+      },
+    });
+
+    return NextResponse.json({
+      nannoJikanDayoCount: updatedQuestion.nannoJikanDayoCount,
+    });
+  } catch (error: any) {
+    console.error('Error incrementing nannoJikanDayoCount:', error);
+    // Check for specific Prisma errors, e.g., if the record to update doesn't exist
+    if (error.code === 'P2025') { // Prisma code for "Record to update not found"
+        return NextResponse.json({ error: 'Question not found' }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: 'Failed to update count', details: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -14,16 +14,47 @@ export async function GET(
 
     const question = await prisma.question.findUnique({
       where: { id },
-      include: {
-            answers: true, // Existing
-            comments: { // Include comments
-              orderBy: {
-                created_at: 'asc', // Show oldest comments first
-              },
-            },
-            _count: { // Include count of likes
-              select: { likes: true },
-            },
+      select: {
+        id: true,
+        title: true,
+        content: true,
+        category: true,
+        status: true,
+        submitter_nickname: true,
+        created_at: true,
+        updated_at: true,
+        notification_token: true, // Assuming this is a field you want to return
+        nannoJikanDayoCount: true, // Explicitly select nannoJikanDayoCount
+        answers: {
+          // Define what fields of answers you need, or true for all
+          // For example:
+          select: {
+            id: true,
+            content: true,
+            responder: true,
+            created_at: true,
+            image_url: true,
+            link_url: true,
+            // question_id: true, // usually not needed if you have the question context
+          }
+        },
+        comments: {
+          orderBy: {
+            created_at: 'asc',
+          },
+          // Define what fields of comments you need, or true for all
+          // For example:
+          select: {
+            id: true,
+            content: true,
+            commenter_name: true,
+            created_at: true,
+            // question_id: true, // usually not needed
+          }
+        },
+        _count: {
+          select: { likes: true },
+        },
       },
     });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function HomePage() {
   return (
     <div className="container mx-auto p-4">
       <div className="flex flex-col sm:flex-row justify-between items-center mb-6 gap-4">
-        <h1 className="text-3xl font-bold text-center sm:text-left">質問一覧</h1>
+        <h1 className="text-3xl font-bold text-center sm:text-left">みなさんの、AIや都市伝説の質問にヘイポーとたまが終止符を打ちます。</h1>
         <QuestionSubmitButton />
       </div>
 

--- a/src/app/question/[id]/page.tsx
+++ b/src/app/question/[id]/page.tsx
@@ -13,7 +13,13 @@ interface FullQuestionData extends QuestionProps {
   id: number;
   answers?: AnswerData[];
   comments: Comment[];
-  _count: { likes: number };
+  _count: {
+    likes: number;
+    // Assuming nannoJikanDayoCount is NOT part of _count from a relation,
+    // but a direct field on the Question model.
+    // If it were a relation count, it would be in _count.
+  };
+  nannoJikanDayoCount: number; // Add this line
   status: string; // Add status to FullQuestionData
   updated_at: string; // Add updated_at to track changes in answers
   submitter_nickname?: string | null; // Add submitter_nickname
@@ -149,6 +155,7 @@ export default function QuestionPage() {
       <InteractionSection
         questionId={questionData.id}
         initialLikes={questionData._count?.likes || 0}
+        initialNannoJikanDayoCount={questionData.nannoJikanDayoCount || 0} // Add this prop
         initialComments={questionData.comments || []}
       />
     </div>

--- a/src/components/InteractionSection.tsx
+++ b/src/components/InteractionSection.tsx
@@ -2,19 +2,22 @@
 import LikeButton from './LikeButton';
 import CommentSection from './CommentSection';
 import { Comment } from '@prisma/client'; // Adjust import as needed
+import NannoJikanDayoButton from './NannoJikanDayoButton';
 
 interface InteractionSectionProps {
   questionId: number;
   initialLikes: number;
+  initialNannoJikanDayoCount: number; // Add this line
   initialComments: Comment[];
 }
 
-export default function InteractionSection({ questionId, initialLikes, initialComments }: InteractionSectionProps) {
+export default function InteractionSection({ questionId, initialLikes, initialNannoJikanDayoCount, initialComments }: InteractionSectionProps) {
   return (
     <div className="bg-white shadow-md rounded-lg p-6 mt-6">
       <h3 className="text-xl font-semibold mb-4">リアクション</h3>
-      <div className="mb-6">
+      <div className="mb-6 flex space-x-4"> {/* Added flex and space-x-4 for layout */}
         <LikeButton questionId={questionId} initialLikes={initialLikes} />
+        <NannoJikanDayoButton questionId={questionId} initialCount={initialNannoJikanDayoCount} />
       </div>
       <hr className="my-6"/>
       <CommentSection questionId={questionId} initialComments={initialComments} />

--- a/src/components/NannoJikanDayoButton.tsx
+++ b/src/components/NannoJikanDayoButton.tsx
@@ -1,0 +1,123 @@
+// src/components/NannoJikanDayoButton.tsx
+'use client';
+import { useState, useEffect } from 'react';
+
+interface NannoJikanDayoButtonProps {
+  questionId: number;
+  initialCount: number;
+}
+
+const HUMOROUS_ANSWERS = [
+  "シャンプー切れたことに気付く時間だよ！",
+  "プテラノドン復活を待つ時間だよ！",
+  "お前が世界線を変える時間だよ！",
+  "メンタルもやしを鍛える時間だよ！",
+  "ダシ昆布を出汁に戻す時間だよ！",
+  "北風がパスタを乾かす時間だよ！",
+  "Wi-Fiが恋する時間だよ！",
+  "左足だけ靴下脱ぐ時間だよ！",
+  "スプーンを曲げずに曲がるのを待つ時間だよ！",
+  "タピオカが目覚める時間だよ！"
+];
+
+export default function NannoJikanDayoButton({ questionId, initialCount }: NannoJikanDayoButtonProps) {
+  const [count, setCount] = useState(initialCount);
+  const [isClickedSession, setIsClickedSession] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showHumorModal, setShowHumorModal] = useState(false);
+  const [currentHumor, setCurrentHumor] = useState('');
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const clickedStatus = localStorage.getItem(`question_${questionId}_nannojikandayo_clicked`);
+      if (clickedStatus === 'true') {
+        setIsClickedSession(true);
+      }
+    }
+  }, [questionId]);
+
+  const handleClick = async () => {
+    if (isClickedSession) {
+      setError("今日はもう押したよ！また明日ね。"); // Or some other message
+      // Optionally, still show a random message if already clicked
+      const randomHumor = HUMOROUS_ANSWERS[Math.floor(Math.random() * HUMOROUS_ANSWERS.length)];
+      setCurrentHumor(randomHumor);
+      setShowHumorModal(true);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/questions/${questionId}/nannojikandayo`, {
+        method: 'POST',
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to update count');
+      }
+      setCount(data.nannoJikanDayoCount);
+      setIsClickedSession(true);
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(`question_${questionId}_nannojikandayo_clicked`, 'true');
+      }
+
+      const randomHumor = HUMOROUS_ANSWERS[Math.floor(Math.random() * HUMOROUS_ANSWERS.length)];
+      setCurrentHumor(randomHumor);
+      setShowHumorModal(true);
+
+    } catch (err: any) {
+      setError(err.message);
+      if (err.message && err.message.includes("already clicked")) {
+        setIsClickedSession(true);
+         if (typeof window !== 'undefined') {
+           localStorage.setItem(`question_${questionId}_nannojikandayo_clicked`, 'true');
+         }
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const closeHumorModal = () => {
+    setShowHumorModal(false);
+    setCurrentHumor('');
+  };
+
+  return (
+    <div className="flex flex-col items-start space-y-2">
+      <button
+        onClick={handleClick}
+        disabled={isLoading} // Removed isClickedSession from disabled to allow showing humor again
+        className={`font-bold py-2 px-4 rounded transition-colors duration-150
+                    ${isClickedSession ? 'bg-blue-300 text-blue-700' // Changed color for clicked state
+                                     : 'bg-blue-500 hover:bg-blue-700 text-white'}
+                    ${isLoading ? 'opacity-50 cursor-wait' : ''}`}
+      >
+        何の時間だよ ({count})
+      </button>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+
+      {showHumorModal && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4"
+          onClick={closeHumorModal} // Close on overlay click
+        >
+          <div
+            className="bg-white p-8 rounded-lg shadow-xl text-center max-w-md mx-auto"
+            onClick={(e) => e.stopPropagation()} // Prevent closing when clicking inside modal content
+          >
+            <p className="text-2xl md:text-3xl font-bold mb-6">{currentHumor}</p>
+            <button
+              onClick={closeHumorModal}
+              className="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-6 rounded-lg shadow transition-colors duration-150 ease-in-out"
+            >
+              閉じる
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
This commit introduces two main features based on your request:

1.  Updates the main heading on the home page to: "みなさんの、AIや都市伝説の質問にヘイポーとたまが終止符を打ちます。"

2.  Adds a new interactive button "何の時間だよ" to the question detail page:
    - This button appears next to the existing "Like" button.
    - Clicking it increments a counter stored in the database for the question.
    - Upon clicking, a randomly selected humorous message is displayed prominently in a modal.
    - Client-side localStorage is used to provide immediate feedback and prevent multiple increments from the same session, though the API currently increments on each valid POST.

Key changes include:
- Modified `src/app/page.tsx` for the new home page heading.
- Updated `prisma/schema.prisma` to add `nannoJikanDayoCount` to the `Question` model. (Note: Migration needs to be run in the target environment).
- Created API endpoint `src/app/api/questions/[id]/nannojikandayo/route.ts` to handle count increments.
- Created `src/components/NannoJikanDayoButton.tsx` for the button component logic and UI.
- Integrated the new button into `src/components/InteractionSection.tsx`.
- Updated `src/app/question/[id]/page.tsx` and the GET API route `src/app/api/questions/[id]/route.ts` to fetch and pass the new count.