### PR TITLE
Fix: Modify LikeButton to always be clickable and remove custom cursors

### DIFF
--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -62,11 +62,10 @@ export default function LikeButton({ questionId, initialLikes }: LikeButtonProps
     <div className="flex items-center space-x-2">
       <button
         onClick={handleLike}
-        disabled={isLiked || isLoading}
         className={`font-bold py-2 px-4 rounded transition-colors duration-150
-                    ${isLiked ? 'bg-red-300 text-red-700 cursor-not-allowed'
+                    ${isLiked ? 'bg-red-300 text-red-700'
                              : 'bg-red-500 hover:bg-red-700 text-white'}
-                    ${isLoading ? 'opacity-50 cursor-wait' : ''}`}
+                    ${isLoading ? 'opacity-50' : ''}`}
       >
         いいね！ ({likes})
       </button>


### PR DESCRIPTION
The LikeButton component was modified to address an issue where it would display a "pause mark" cursor and become unclickable when already liked or during loading.

Changes made:
- Removed the `disabled` attribute from the button, allowing it to always be clicked.
- Removed `cursor-not-allowed` style when the button is in the "liked" state.
- Removed `cursor-wait` style when the button is in the "loading" state.

The `handleLike` function's existing logic continues to prevent multiple like operations or requests if the item is already liked or a request is in progress, by returning early and displaying an error message to you. This change improves the user experience by making the button feel more responsive and avoiding potentially confusing cursor states, while maintaining the integrity of the like functionality.