### PR TITLE
Refactor: LikeButton relies on server for like validation

### DIFF
--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -13,22 +13,7 @@ export default function LikeButton({ questionId, initialLikes }: LikeButtonProps
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Check localStorage if user has liked this question before (simple anonymous tracking)
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const likedStatus = localStorage.getItem(`question_${questionId}_liked`);
-      if (likedStatus === 'true') {
-        setIsLiked(true);
-      }
-    }
-  }, [questionId]);
-
   const handleLike = async () => {
-    if (isLiked) {
-      // Optional: Implement unliking, or just prevent multiple likes from same client session
-      setError("You've already liked this.");
-      return;
-    }
     setIsLoading(true);
     setError(null);
     try {


### PR DESCRIPTION
I've modified the LikeButton component to ensure that like attempts are always validated by the server. This addresses an issue where client-side checks could prematurely indicate an item was already liked.

Changes:
- I removed the useEffect hook that initialized the `isLiked` state from localStorage. The `isLiked` state now defaults to false on mount.
- I removed the initial client-side `if (isLiked)` check within the `handleLike` function. This ensures that every click on the like button attempts an API call to the backend.
- The component now relies on the server's response to determine the true liked status, update the UI (including the error message "You've already liked this." when appropriate), and set the `isLiked` state and localStorage accordingly.

This change ensures that the backend is the single source of truth for like counts and your like status, aligning with the requirement that each user can like an item once.