### PR TITLE
Refactor: Adjust NannoJikanDayoButton popup position

### DIFF
--- a/src/components/NannoJikanDayoButton.tsx
+++ b/src/components/NannoJikanDayoButton.tsx
@@ -82,7 +82,7 @@ export default function NannoJikanDayoButton({ questionId, initialCount }: Nanno
   };
 
   return (
-    <div className="flex flex-col items-start space-y-2">
+    <div className="flex flex-col items-start space-y-2 relative"> {/* Added relative for potential future positioning needs, not strictly necessary for fixed popup */}
       <button
         onClick={handleClick}
         disabled={isLoading} // Only disable while loading, allow re-clicks if already isClicked to show message again
@@ -93,9 +93,9 @@ export default function NannoJikanDayoButton({ questionId, initialCount }: Nanno
       >
         何の時間だよ ({count})
       </button>
-      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {error && <p className="text-red-500 text-sm mt-2">{error}</p>} {/* Added mt-2 for spacing if message is also shown */}
       {displayedMessage && (
-        <div className="mt-4 p-4 bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700">
+        <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 p-6 bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 shadow-xl rounded-lg">
           <p className="text-xl font-semibold">{displayedMessage}</p>
         </div>
       )}


### PR DESCRIPTION
This commit addresses two points for the "何の時間だよ" button:

1.  Count Display:
    - I verified that the component already displays the count (passed as `initialCount`) before any button click. No code changes were necessary for this aspect as the existing implementation meets the requirement.

2.  Popup Message Position:
    - I modified `src/components/NannoJikanDayoButton.tsx` to change the popup message's position.
    - The popup is now centered on the screen using fixed positioning with Tailwind CSS classes (`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50`).
    - I also added minor styling enhancements (padding, shadow, rounded corners) to the popup message for better visual appearance.