### PR TITLE
feat: Implement pagination for question list

### DIFF
--- a/src/app/api/questions/route.test.ts
+++ b/src/app/api/questions/route.test.ts
@@ -1,0 +1,179 @@
+import { GET } from './route'; // Adjust the import path as necessary
+import prisma from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+import { URL } from 'url'; // Import URL
+
+// Mock Prisma
+jest.mock('@/lib/prisma', () => ({
+  question: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+}));
+
+// Helper to create a mock NextRequest
+const mockRequest = (queryParams: Record<string, string>): NextRequest => {
+  const url = new URL(`http://localhost/api/questions?${new URLSearchParams(queryParams)}`);
+  return {
+    url: url.toString(),
+    // Add other NextRequest properties if needed by your handler
+  } as NextRequest;
+};
+
+describe('GET /api/questions', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    (prisma.question.findMany as jest.Mock).mockReset();
+    (prisma.question.count as jest.Mock).mockReset();
+  });
+
+  test('Test Case 1: Default parameters', async () => {
+    const mockQuestions = [{ id: '1', title: 'Test Question' }];
+    const mockTotalCount = 1;
+
+    (prisma.question.findMany as jest.Mock).mockResolvedValue(mockQuestions);
+    (prisma.question.count as jest.Mock).mockResolvedValue(mockTotalCount);
+
+    const request = mockRequest({});
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(prisma.question.count).toHaveBeenCalledWith({ where: {} });
+    expect(prisma.question.findMany).toHaveBeenCalledWith({
+      where: {},
+      orderBy: { created_at: 'desc' },
+      skip: 0,
+      take: 10,
+    });
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      questions: mockQuestions,
+      totalCount: mockTotalCount,
+      page: 1,
+      limit: 10,
+    });
+  });
+
+  test('Test Case 2: Specific page', async () => {
+    const mockQuestions = [{ id: '2', title: 'Test Question Page 2' }];
+    const mockTotalCount = 11;
+
+    (prisma.question.findMany as jest.Mock).mockResolvedValue(mockQuestions);
+    (prisma.question.count as jest.Mock).mockResolvedValue(mockTotalCount);
+
+    const request = mockRequest({ page: '2' });
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(prisma.question.count).toHaveBeenCalledWith({ where: {} });
+    expect(prisma.question.findMany).toHaveBeenCalledWith({
+      where: {},
+      orderBy: { created_at: 'desc' },
+      skip: 10,
+      take: 10,
+    });
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      questions: mockQuestions,
+      totalCount: mockTotalCount,
+      page: 2,
+      limit: 10,
+    });
+  });
+
+  test('Test Case 3: With category filter and pagination', async () => {
+    const mockQuestions = [{ id: '3', title: 'AI Question Page 3' }];
+    const mockTotalCount = 25;
+
+    (prisma.question.findMany as jest.Mock).mockResolvedValue(mockQuestions);
+    (prisma.question.count as jest.Mock).mockResolvedValue(mockTotalCount);
+
+    const request = mockRequest({ category: 'AI', page: '3' });
+    const response = await GET(request);
+    const body = await response.json();
+
+    const expectedWhereClause = { category: 'AI' };
+    expect(prisma.question.count).toHaveBeenCalledWith({ where: expectedWhereClause });
+    expect(prisma.question.findMany).toHaveBeenCalledWith({
+      where: expectedWhereClause,
+      orderBy: { created_at: 'desc' },
+      skip: 20,
+      take: 10,
+    });
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      questions: mockQuestions,
+      totalCount: mockTotalCount,
+      page: 3,
+      limit: 10,
+    });
+  });
+
+  test('Test Case 4a: Page out of bounds (page=0)', async () => {
+    const mockQuestions = [{ id: '1', title: 'Test Question Page 1' }]; // Should return page 1
+    const mockTotalCount = 5;
+
+    (prisma.question.findMany as jest.Mock).mockResolvedValue(mockQuestions);
+    (prisma.question.count as jest.Mock).mockResolvedValue(mockTotalCount);
+
+    const request = mockRequest({ page: '0' });
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(prisma.question.count).toHaveBeenCalledWith({ where: {} });
+    expect(prisma.question.findMany).toHaveBeenCalledWith({
+      where: {},
+      orderBy: { created_at: 'desc' },
+      skip: 0, // For page=0, it defaults to page 1, so skip is 0
+      take: 10,
+    });
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      questions: mockQuestions,
+      totalCount: mockTotalCount,
+      page: 1, // Page should be corrected to 1
+      limit: 10,
+    });
+  });
+
+  test('Test Case 4b: Page out of bounds (page too high)', async () => {
+    const mockQuestions: any[] = []; // No questions for a page too high
+    const mockTotalCount = 25; // Still have a total count
+
+    (prisma.question.findMany as jest.Mock).mockResolvedValue(mockQuestions);
+    (prisma.question.count as jest.Mock).mockResolvedValue(mockTotalCount);
+
+    const request = mockRequest({ page: '100' }); // Assuming only 3 pages of data (25 items / 10 per page)
+    const response = await GET(request);
+    const body = await response.json();
+
+    const expectedWhereClause = {}; // No category specified
+    expect(prisma.question.count).toHaveBeenCalledWith({ where: expectedWhereClause });
+    expect(prisma.question.findMany).toHaveBeenCalledWith({
+      where: expectedWhereClause,
+      orderBy: { created_at: 'desc' },
+      skip: (100 - 1) * 10, // skip will be 990
+      take: 10,
+    });
+    expect(response.status).toBe(200);
+    expect(body.questions).toEqual([]);
+    expect(body.totalCount).toBe(mockTotalCount);
+    expect(body.page).toBe(100); // API returns the requested page number
+    expect(body.limit).toBe(10);
+  });
+
+  test('Category "all" should result in an empty where clause', async () => {
+    (prisma.question.count as jest.Mock).mockResolvedValue(0);
+    (prisma.question.findMany as jest.Mock).mockResolvedValue([]);
+
+    const request = mockRequest({ category: 'all', page: '1' });
+    await GET(request);
+
+    expect(prisma.question.count).toHaveBeenCalledWith({
+      where: {}, // Empty where clause
+    });
+     expect(prisma.question.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: {}, // Empty where clause
+    }));
+  });
+});

--- a/src/components/QuestionList.tsx
+++ b/src/components/QuestionList.tsx
@@ -1,7 +1,7 @@
 // src/components/QuestionList.tsx
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import QuestionCard, { QuestionCardProps } from './QuestionCard';
 import Spinner from './Spinner'; // Import Spinner
 
@@ -13,41 +13,110 @@ export default function QuestionList({ selectedCategory }: QuestionListProps) {
   const [questions, setQuestions] = useState<QuestionCardProps[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const limit = 10; // Fixed limit as per requirements
+
+  const fetchQuestions = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      let url = `/api/questions?page=${currentPage}&limit=${limit}`;
+      if (selectedCategory && selectedCategory.toLowerCase() !== 'all') {
+        url += `&category=${encodeURIComponent(selectedCategory)}`;
+      } else {
+        // Ensure category parameter is not empty if 'all' or null
+        url += `&category=all`;
+      }
+
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch questions: ${response.statusText}`);
+      }
+      const data = await response.json();
+      setQuestions(data.questions || []); // Ensure questions is always an array
+      setTotalCount(data.totalCount || 0);
+      // If API returned limit, we could set it: setLimit(data.limit);
+    } catch (err: any) {
+      setError(err.message);
+      setQuestions([]); // Clear questions on error
+      setTotalCount(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [currentPage, selectedCategory, limit]);
 
   useEffect(() => {
-    async function fetchQuestions() {
-      try {
-        setLoading(true);
-        setError(null); // Reset error on new fetch
-        let url = '/api/questions';
-        if (selectedCategory && selectedCategory.toLowerCase() !== 'all') {
-          url += `?category=${encodeURIComponent(selectedCategory)}`;
-        }
-
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error(`Failed to fetch questions: ${response.statusText}`);
-        }
-        const data = await response.json();
-        setQuestions(data);
-      } catch (err: any) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    }
     fetchQuestions();
-  }, [selectedCategory]); // Re-fetch when selectedCategory changes
+  }, [fetchQuestions]);
 
-  if (loading) return <Spinner />;
+  // Reset to page 1 when category changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [selectedCategory]);
+
+  const handlePreviousPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1);
+    }
+  };
+
+  const totalPages = Math.ceil(totalCount / limit);
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages) {
+      setCurrentPage(currentPage + 1);
+    }
+  };
+
+  if (loading && questions.length === 0) return <Spinner />; // Show spinner only on initial load or if questions are empty
   if (error) return <p className="text-red-500 text-center py-4">Error: {error}</p>;
-  if (questions.length === 0) return <p className="text-center py-4">該当する質問はありません。</p>;
+
+  const startItem = totalCount === 0 ? 0 : (currentPage - 1) * limit + 1;
+  const endItem = Math.min(currentPage * limit, totalCount);
 
   return (
     <div>
-      {questions.map((question) => (
-        <QuestionCard key={question.id} {...question} />
-      ))}
+      {questions.length > 0 ? (
+        questions.map((question) => (
+          <QuestionCard key={question.id} {...question} />
+        ))
+      ) : (
+        !loading && <p className="text-center py-4">該当する質問はありません。</p>
+        // Show "no questions" only if not loading and totalCount is 0 (implicitly, as questions would be empty)
+        // Or if totalCount > 0 but current page has no items (which shouldn't happen with correct totalCount)
+      )}
+
+      {totalCount > 0 && (
+        <div className="mt-8 flex flex-col items-center space-y-4">
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            Showing <span className="font-semibold">{startItem}</span>
+            {' - '}
+            <span className="font-semibold">{endItem}</span>
+            {' of '}
+            <span className="font-semibold">{totalCount}</span> questions
+          </p>
+          <div className="flex justify-center items-center space-x-4">
+            <button
+              onClick={handlePreviousPage}
+              disabled={currentPage === 1 || loading}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-500 rounded-md hover:bg-blue-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
+            >
+              Previous
+            </button>
+            <span className="text-sm">
+              Page {currentPage} of {totalPages}
+            </span>
+            <button
+              onClick={handleNextPage}
+              disabled={currentPage === totalPages || loading}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-500 rounded-md hover:bg-blue-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/__tests__/QuestionList.test.tsx
+++ b/src/components/__tests__/QuestionList.test.tsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QuestionList from '../QuestionList'; // Adjust path as needed
+import '@testing-library/jest-dom';
+
+// Mock fetch
+global.fetch = jest.fn();
+
+// Mock QuestionCard to simplify testing QuestionList
+jest.mock('../QuestionCard', () => (props: any) => (
+  <div data-testid="question-card">
+    <h2 data-testid={`question-title-${props.id}`}>{props.title}</h2>
+    <p>{props.content}</p>
+    <p>Category: {props.category}</p>
+  </div>
+));
+
+// Mock Spinner
+jest.mock('../Spinner', () => () => <div data-testid="spinner">Loading...</div>);
+
+const mockQuestion = (id: string, title: string, category: string = 'AI') => ({
+  id,
+  title,
+  content: `Content for ${title}`,
+  category,
+  submitter_nickname: 'Tester',
+  created_at: new Date().toISOString(),
+  status: 'approved',
+  like_count: 0,
+  comment_count: 0,
+});
+
+describe('QuestionList Pagination', () => {
+  beforeEach(() => {
+    (fetch as jest.Mock).mockClear();
+  });
+
+  const mockApiResponse = (questions: any[], totalCount: number, page: number, limit: number = 10) => ({
+    questions,
+    totalCount,
+    page,
+    limit,
+  });
+
+  test('Test Case 1: Initial render (first page)', async () => {
+    const page1Questions = Array.from({ length: 10 }, (_, i) => mockQuestion(`q${i+1}`, `Question ${i+1}`));
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockApiResponse(page1Questions, 25, 1),
+    });
+
+    render(<QuestionList selectedCategory="all" />);
+
+    await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
+
+    expect(screen.getAllByTestId('question-card')).toHaveLength(10);
+    expect(screen.getByText(`Question 1`)).toBeInTheDocument();
+    expect(screen.getByText('Previous')).toBeDisabled();
+    expect(screen.getByText('Next')).toBeEnabled();
+    expect(screen.getByText('Showing 1 - 10 of 25 questions')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument(); // 25 items, 10 per page = 3 pages
+  });
+
+  test('Test Case 2: Clicking "Next" button', async () => {
+    const page1Questions = Array.from({ length: 10 }, (_, i) => mockQuestion(`q${i+1}`, `Question ${i+1}`));
+    const page2Questions = Array.from({ length: 10 }, (_, i) => mockQuestion(`q${i+11}`, `Question ${i+11}`));
+
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({ // Initial load (page 1)
+        ok: true,
+        json: async () => mockApiResponse(page1Questions, 25, 1),
+      })
+      .mockResolvedValueOnce({ // Load after clicking Next (page 2)
+        ok: true,
+        json: async () => mockApiResponse(page2Questions, 25, 2),
+      });
+
+    render(<QuestionList selectedCategory="all" />);
+    await waitFor(() => expect(screen.getByText('Page 1 of 3')).toBeInTheDocument());
+
+    await act(async () => {
+      userEvent.click(screen.getByText('Next'));
+    });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    expect(fetch).toHaveBeenLastCalledWith('/api/questions?page=2&limit=10&category=all');
+
+    expect(screen.getAllByTestId('question-card')).toHaveLength(10);
+    expect(screen.getByText(`Question 11`)).toBeInTheDocument();
+    expect(screen.getByText('Previous')).toBeEnabled();
+    expect(screen.getByText('Next')).toBeEnabled(); // Still page 2 of 3
+    expect(screen.getByText('Showing 11 - 20 of 25 questions')).toBeInTheDocument();
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument();
+  });
+
+  test('Test Case 3: Clicking "Previous" button', async () => {
+    const page1Questions = Array.from({ length: 10 }, (_, i) => mockQuestion(`q${i+1}`, `Question ${i+1}`));
+    const page2Questions = Array.from({ length: 10 }, (_, i) => mockQuestion(`q${i+11}`, `Question ${i+11}`));
+
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({ // Initial load (page 1 for setup)
+        ok: true,
+        json: async () => mockApiResponse(page1Questions, 25, 1),
+      })
+      .mockResolvedValueOnce({ // Load for page 2
+        ok: true,
+        json: async () => mockApiResponse(page2Questions, 25, 2),
+      })
+      .mockResolvedValueOnce({ // Load for page 1 (after clicking Previous)
+        ok: true,
+        json: async () => mockApiResponse(page1Questions, 25, 1),
+      });
+
+    render(<QuestionList selectedCategory="all" />);
+    // Initial load to page 1
+    await waitFor(() => expect(screen.getByText('Page 1 of 3')).toBeInTheDocument());
+
+    // Go to page 2
+    await act(async () => {
+      userEvent.click(screen.getByText('Next'));
+    });
+    await waitFor(() => expect(screen.getByText('Page 2 of 3')).toBeInTheDocument());
+    expect(screen.getByText(`Question 11`)).toBeInTheDocument();
+
+
+    // Click Previous
+    await act(async () => {
+      userEvent.click(screen.getByText('Previous'));
+    });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
+    expect(fetch).toHaveBeenLastCalledWith('/api/questions?page=1&limit=10&category=all');
+
+    expect(screen.getAllByTestId('question-card')).toHaveLength(10);
+    expect(screen.getByText(`Question 1`)).toBeInTheDocument();
+    expect(screen.getByText('Previous')).toBeDisabled();
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
+  });
+
+  test('Test Case 4: Last page', async () => {
+    const page1Questions = Array.from({ length: 10 }, (_, i) => mockQuestion(`q${i+1}`, `Question ${i+1}`));
+    const page2Questions = Array.from({ length: 10 }, (_, i) => mockQuestion(`q${i+11}`, `Question ${i+11}`));
+    const page3Questions = Array.from({ length: 5 }, (_, i) => mockQuestion(`q${i+21}`, `Question ${i+21}`));
+
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => mockApiResponse(page1Questions, 25, 1) }) // Page 1
+      .mockResolvedValueOnce({ ok: true, json: async () => mockApiResponse(page2Questions, 25, 2) }) // Page 2
+      .mockResolvedValueOnce({ ok: true, json: async () => mockApiResponse(page3Questions, 25, 3) }); // Page 3
+
+    render(<QuestionList selectedCategory="all" />);
+    await waitFor(() => expect(screen.getByText('Page 1 of 3')).toBeInTheDocument());
+
+    await act(async () => { userEvent.click(screen.getByText('Next')); }); // Go to Page 2
+    await waitFor(() => expect(screen.getByText('Page 2 of 3')).toBeInTheDocument());
+
+    await act(async () => { userEvent.click(screen.getByText('Next')); }); // Go to Page 3
+    await waitFor(() => expect(screen.getByText('Page 3 of 3')).toBeInTheDocument());
+
+    expect(fetch).toHaveBeenLastCalledWith('/api/questions?page=3&limit=10&category=all');
+    expect(screen.getAllByTestId('question-card')).toHaveLength(5);
+    expect(screen.getByText(`Question 21`)).toBeInTheDocument();
+    expect(screen.getByText('Previous')).toBeEnabled();
+    expect(screen.getByText('Next')).toBeDisabled();
+    expect(screen.getByText('Showing 21 - 25 of 25 questions')).toBeInTheDocument();
+  });
+
+  test('Test Case 5: No questions', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockApiResponse([], 0, 1),
+    });
+
+    render(<QuestionList selectedCategory="all" />);
+
+    await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
+
+    expect(screen.getByText('該当する質問はありません。')).toBeInTheDocument();
+    expect(screen.queryByText('Previous')).not.toBeInTheDocument();
+    expect(screen.queryByText('Next')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Showing .* questions/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Page .* of .*/)).not.toBeInTheDocument();
+  });
+
+  test('Test Case 6: Category change resets to page 1', async () => {
+    const aiPage1Questions = [mockQuestion('ai1', 'AI Question 1', 'AI')];
+    const aiPage2Questions = [mockQuestion('ai2', 'AI Question 2', 'AI')];
+    const techPage1Questions = [mockQuestion('tech1', 'Tech Question 1', '都市伝説')];
+
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({ // Initial load: AI, Page 1
+        ok: true,
+        json: async () => mockApiResponse(aiPage1Questions, 15, 1), // 15 total AI questions -> 2 pages
+      })
+      .mockResolvedValueOnce({ // AI, Page 2
+        ok: true,
+        json: async () => mockApiResponse(aiPage2Questions, 15, 2),
+      })
+      .mockResolvedValueOnce({ // Tech, Page 1
+        ok: true,
+        json: async () => mockApiResponse(techPage1Questions, 5, 1), // 5 tech questions -> 1 page
+      });
+
+    const { rerender } = render(<QuestionList selectedCategory="AI" />);
+
+    // Load AI Page 1
+    await waitFor(() => {
+      expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+      expect(screen.getByText('AI Question 1')).toBeInTheDocument();
+    });
+
+    // Go to AI Page 2
+    await act(async () => {
+      userEvent.click(screen.getByText('Next'));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+      expect(screen.getByText('AI Question 2')).toBeInTheDocument();
+      expect(fetch).toHaveBeenLastCalledWith('/api/questions?page=2&limit=10&category=AI');
+    });
+
+    // Change category to '都市伝説'
+    act(() => {
+      rerender(<QuestionList selectedCategory="都市伝説" />);
+    });
+
+    // Should fetch Page 1 of '都市伝説'
+    await waitFor(() => {
+      expect(fetch).toHaveBeenLastCalledWith('/api/questions?page=1&limit=10&category=%E9%83%BD%E5%B8%82%E4%BC%9D%E8%AA%AC'); // 都市伝説 URI encoded
+    });
+
+    await waitFor(() => {
+        expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
+        expect(screen.getByText('Tech Question 1')).toBeInTheDocument();
+    });
+    // Ensure current page is reset and displayed correctly
+    expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This commit introduces pagination to the question list feature.

Key changes:

1.  **API (`src/app/api/questions/route.ts`):**
    *   The `GET` endpoint now accepts `page` query parameter (defaults to 1).
    *   `limit` is fixed at 10 items per page.
    *   The API returns a paginated list of questions along with `totalCount`, current `page`, and `limit`.
    *   Handles invalid or out-of-bounds page numbers gracefully by defaulting to page 1.

2.  **Frontend (`src/components/QuestionList.tsx`):**
    *   Added state for current page, total question count.
    *   Fetches paginated questions from the API based on the current page and selected category.
    *   Displays "Previous" and "Next" buttons, which are enabled/disabled based on the current page and total pages.
    *   Shows an item count (e.g., "Showing 1-10 of 100 questions").
    *   Displays current page number (e.g., "Page 1 of 10").
    *   Resets to page 1 when the category filter changes.

3.  **Tests:**
    *   Added API tests (`src/app/api/questions/route.test.ts`) to verify pagination logic (page, limit, category filtering, out-of-bounds pages).
    *   Added component tests (`src/components/__tests__/QuestionList.test.tsx`) for `QuestionList` to verify UI elements (buttons, item count, page display), navigation between pages, and behavior with no questions or when changing categories.