### PR TITLE
feat: Add 'Return to Home' button to question detail page

### DIFF
--- a/src/app/question/[id]/page.tsx
+++ b/src/app/question/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'next/navigation';
 import QuestionDetailDisplay, { QuestionProps } from '@/components/QuestionDetail'; // Ensure QuestionProps is exported or defined
 import AnswerSection, { AnswerProps as AnswerData } from '@/components/AnswerSection'; // Ensure AnswerProps is exported or defined
 import InteractionSection from '@/components/InteractionSection';
+import ReturnToHomeButton from '@/components/ReturnToHomeButton';
 import { Comment } from '@prisma/client'; // Or local interface
 import Spinner from '@/components/Spinner'; // Import Spinner
 
@@ -155,6 +156,9 @@ export default function QuestionPage() {
         initialNannoJikanDayoClicks={questionData._count?.nannoJikanDayoClicks || 0} // Add this
         initialComments={questionData.comments || []}
       />
+      <div className="flex justify-center mt-8">
+        <ReturnToHomeButton />
+      </div>
     </div>
   );
 }

--- a/src/components/ReturnToHomeButton.tsx
+++ b/src/components/ReturnToHomeButton.tsx
@@ -1,0 +1,14 @@
+// src/components/ReturnToHomeButton.tsx
+import Link from 'next/link';
+
+export default function ReturnToHomeButton() {
+  return (
+    <Link href="/" passHref>
+      <button
+        className="font-bold py-2 px-4 rounded transition-colors duration-150 bg-blue-500 hover:bg-blue-700 text-white"
+      >
+        ホーム画面に戻る
+      </button>
+    </Link>
+  );
+}


### PR DESCRIPTION
- I created a new `ReturnToHomeButton` component.
- I added the button to the bottom of the question detail page (`src/app/question/[id]/page.tsx`).
- I styled the button to be consistent with the existing design, using a blue color scheme.