### PR TITLE
feat: Add navigation between questions

### DIFF
--- a/src/components/QuestionNavigation.tsx
+++ b/src/components/QuestionNavigation.tsx
@@ -1,0 +1,44 @@
+// src/components/QuestionNavigation.tsx
+import Link from 'next/link';
+import React from 'react'; // Import React for React.FC
+
+interface QuestionNavigationProps {
+  previousQuestionId: string | null;
+  nextQuestionId: string | null;
+}
+
+const QuestionNavigation: React.FC<QuestionNavigationProps> = ({ previousQuestionId, nextQuestionId }) => {
+  const commonButtonClasses = "font-bold py-2 px-4 rounded";
+  const activeButtonClasses = `bg-blue-500 hover:bg-blue-700 text-white ${commonButtonClasses}`;
+  const disabledButtonClasses = `bg-gray-300 text-gray-500 ${commonButtonClasses} cursor-not-allowed`;
+
+  return (
+    <div className="flex justify-between my-8"> {/* Increased margin to my-8 for more spacing */}
+      {previousQuestionId ? (
+        <Link href={`/question/${previousQuestionId}`} passHref>
+          <button className={activeButtonClasses}>
+            ← 前の質問へ
+          </button>
+        </Link>
+      ) : (
+        <span className={disabledButtonClasses}>
+          ← 前の質問へ
+        </span>
+      )}
+
+      {nextQuestionId ? (
+        <Link href={`/question/${nextQuestionId}`} passHref>
+          <button className={activeButtonClasses}>
+            次の質問へ →
+          </button>
+        </Link>
+      ) : (
+        <span className={disabledButtonClasses}>
+          次の質問へ →
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default QuestionNavigation;

--- a/src/components/__tests__/QuestionNavigation.test.tsx
+++ b/src/components/__tests__/QuestionNavigation.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import QuestionNavigation from '../QuestionNavigation';
+
+// Mock next/link
+jest.mock('next/link', () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => {
+    // Directly render the button/span child and pass href to an 'a' tag if button is child
+    // This is a simplified mock. For buttons inside Link, we might need to check props differently.
+    // For this component, the button is a direct child.
+    if (React.isValidElement(children) && typeof children.type === 'function') { // Check if children is a React component (like our button)
+         // This mock assumes the children of Link is a simple element like a button or span
+         // and it will have its props checked directly.
+         // For this specific component, we render the child and check its props or what it renders.
+         // The <Link> itself would typically render an <a> tag.
+         // Let's try to make the mock render the child as is, and check the href prop passed to Link.
+         // We can verify the href by checking the props of the mocked Link component.
+         // However, a simpler way for this case is to render an actual <a> tag.
+        return <a href={href}>{children}</a>;
+    }
+    return <div data-testid="mock-link" data-href={href}>{children}</div>; // Fallback for other children types
+  };
+});
+
+
+describe('QuestionNavigation Component', () => {
+  const previousText = '← 前の質問へ';
+  const nextText = '次の質問へ →';
+
+  test('renders both buttons active when both IDs are provided', () => {
+    render(<QuestionNavigation previousQuestionId="123" nextQuestionId="456" />);
+
+    const prevLink = screen.getByText(previousText).closest('a');
+    expect(prevLink).toBeInTheDocument();
+    expect(prevLink).toHaveAttribute('href', '/question/123');
+    expect(screen.getByText(previousText)).not.toHaveClass('cursor-not-allowed');
+    expect(screen.getByText(previousText)).toHaveClass('bg-blue-500');
+
+
+    const nextLink = screen.getByText(nextText).closest('a');
+    expect(nextLink).toBeInTheDocument();
+    expect(nextLink).toHaveAttribute('href', '/question/456');
+    expect(screen.getByText(nextText)).not.toHaveClass('cursor-not-allowed');
+    expect(screen.getByText(nextText)).toHaveClass('bg-blue-500');
+  });
+
+  test('renders previous button disabled and next button active', () => {
+    render(<QuestionNavigation previousQuestionId={null} nextQuestionId="456" />);
+
+    const prevButton = screen.getByText(previousText);
+    expect(prevButton).toBeInTheDocument();
+    expect(prevButton).toHaveClass('cursor-not-allowed');
+    expect(prevButton).toHaveClass('bg-gray-300');
+    expect(prevButton.closest('a')).toBeNull(); // Should not be a link
+
+    const nextLink = screen.getByText(nextText).closest('a');
+    expect(nextLink).toBeInTheDocument();
+    expect(nextLink).toHaveAttribute('href', '/question/456');
+    expect(screen.getByText(nextText)).not.toHaveClass('cursor-not-allowed');
+    expect(screen.getByText(nextText)).toHaveClass('bg-blue-500');
+  });
+
+  test('renders previous button active and next button disabled', () => {
+    render(<QuestionNavigation previousQuestionId="123" nextQuestionId={null} />);
+
+    const prevLink = screen.getByText(previousText).closest('a');
+    expect(prevLink).toBeInTheDocument();
+    expect(prevLink).toHaveAttribute('href', '/question/123');
+    expect(screen.getByText(previousText)).not.toHaveClass('cursor-not-allowed');
+    expect(screen.getByText(previousText)).toHaveClass('bg-blue-500');
+
+    const nextButton = screen.getByText(nextText);
+    expect(nextButton).toBeInTheDocument();
+    expect(nextButton).toHaveClass('cursor-not-allowed');
+    expect(nextButton).toHaveClass('bg-gray-300');
+    expect(nextButton.closest('a')).toBeNull(); // Should not be a link
+  });
+
+  test('renders both buttons disabled when both IDs are null', () => {
+    render(<QuestionNavigation previousQuestionId={null} nextQuestionId={null} />);
+
+    const prevButton = screen.getByText(previousText);
+    expect(prevButton).toBeInTheDocument();
+    expect(prevButton).toHaveClass('cursor-not-allowed');
+    expect(prevButton).toHaveClass('bg-gray-300');
+    expect(prevButton.closest('a')).toBeNull();
+
+    const nextButton = screen.getByText(nextText);
+    expect(nextButton).toBeInTheDocument();
+    expect(nextButton).toHaveClass('cursor-not-allowed');
+    expect(nextButton).toHaveClass('bg-gray-300');
+    expect(nextButton.closest('a')).toBeNull();
+  });
+});


### PR DESCRIPTION
This commit introduces a navigation feature on the question detail page, allowing you to move to the previous or next question based on their posting date.

Key changes:

1.  **API Enhancement (`src/app/api/questions/route.ts`)**:
    *   The `GET /api/questions` endpoint now accepts `currentQuestionId` and `currentQuestionCreatedAt` query parameters.
    *   When these parameters are provided, the API returns `previousQuestionId` and `nextQuestionId` by querying questions with earlier or later `created_at` timestamps.
    *   The existing functionality for listing questions remains unchanged.

2.  **Question Page Update (`src/app/question/[id]/page.tsx`)**:
    *   The page now fetches the previous and next question IDs after loading the current question's data.
    *   These IDs are stored in the component's state.

3.  **New Navigation Component (`src/components/QuestionNavigation.tsx`)**:
    *   A new reusable component, `QuestionNavigation`, displays "← 前の質問へ" and "次の質問へ →" buttons.
    *   Buttons are implemented using Next.js `Link` for navigation.
    *   Buttons are disabled (visually and functionally) if there is no previous or next question, respectively.

4.  **Integration**:
    *   The `QuestionNavigation` component is integrated into the question detail page, using the fetched previous/next IDs.

5.  **Tests**:
    *   Unit tests were added for the API endpoint in `src/app/api/questions/route.test.ts` to verify the logic for finding previous/next question IDs.
    *   Unit tests were added for the `QuestionNavigation` component in `src/components/__tests__/QuestionNavigation.test.tsx` to verify button states (active/disabled) and correct link generation.

This feature enhances your experience by providing an easy way to browse through questions sequentially.