### PR TITLE
feat: メイン画面に質問検索機能を追加

### DIFF
--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -58,6 +58,7 @@ export async function GET(request: Request) {
       const category = searchParams.get('category');
       const sort = searchParams.get('sort');
       const pageParam = searchParams.get('page');
+      const search = searchParams.get('search');
       // const limitParam = searchParams.get('limit'); // Though we'll hardcode limit to 10 for now
 
       let page = pageParam ? parseInt(pageParam, 10) : 1;
@@ -70,6 +71,26 @@ export async function GET(request: Request) {
       const whereClause: any = {};
       if (category && category.trim() !== '' && category.toLowerCase() !== 'all') {
         whereClause.category = category;
+      }
+
+      if (search && search.trim() !== '') {
+        const keywords = search.trim().split(/\s+/); // Split by one or more spaces
+        whereClause.AND = keywords.map(keyword => ({
+          OR: [
+            {
+              title: {
+                contains: keyword,
+                mode: 'insensitive',
+              },
+            },
+            {
+              content: {
+                contains: keyword,
+                mode: 'insensitive',
+              },
+            },
+          ],
+        }));
       }
 
       const totalCount = await prisma.question.count({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,11 @@
 'use client'; // Needs to be client component for useState
 import { useState } from 'react';
 import Link from 'next/link'; // Make sure Link is imported
+// It's good practice to keep imports alphabetized or grouped, but for this tool, directness is key.
+// For icons, I'll use simple text for now: "Search" and "Clear".
+// If specific icons like magnifying glass or 'x' are required as components (e.g., from a library),
+// that would be a separate step, possibly involving installing an icon library.
+// For now, textual representation will suffice for functionality.
 import QuestionList from '@/components/QuestionList';
 import QuestionSubmitButton from '@/components/QuestionSubmitButton';
 
@@ -9,6 +14,8 @@ const CATEGORIES = ['all', 'AI', '都市伝説', 'その他']; // 'all' maps to 
 
 export default function HomePage() {
   const [selectedCategory, setSelectedCategory] = useState<string | null>('all');
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [searchInput, setSearchInput] = useState<string>('');
 
   return (
     <div className="container mx-auto p-4">
@@ -39,7 +46,33 @@ export default function HomePage() {
         ))}
       </div>
 
-      <QuestionList selectedCategory={selectedCategory} />
+      {/* Search UI Elements */}
+      <div className="mb-6 flex items-center gap-2">
+        <input
+          type="text"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="キーワード検索..."
+          className="flex-grow px-4 py-2 border border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500"
+        />
+        <button
+          onClick={() => setSearchTerm(searchInput)}
+          className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-50"
+        >
+          検索 {/* Using text for search icon */}
+        </button>
+        <button
+          onClick={() => {
+            setSearchInput('');
+            setSearchTerm('');
+          }}
+          className="px-4 py-2 bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-50"
+        >
+          クリア {/* Using text for clear icon */}
+        </button>
+      </div>
+
+      <QuestionList selectedCategory={selectedCategory} searchTerm={searchTerm} />
 
       {/* Add the new button here */}
       <div className="mt-12 text-center">

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -4,17 +4,48 @@ import Link from 'next/link';
 export interface QuestionCardProps {
   id: number;
   title: string;
+  content?: string; // Added content, assuming it might be used or passed in future for full card view
   category?: string | null;
   created_at: string;
   status: string;
+  searchTerm?: string; // Optional: for highlighting search terms
   //いいね数 (likesCount) will be added later
 }
 
-export default function QuestionCard({ id, title, category, created_at, status }: QuestionCardProps) {
+// Helper function to escape regex special characters
+const escapeRegExp = (string: string) => {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+};
+
+const highlightText = (text: string | undefined, term: string | undefined) => {
+  if (!text) return '';
+  if (!term || term.trim() === '') {
+    return text;
+  }
+
+  const keywords = term.trim().split(/\s+/).filter(Boolean); // Split by space and remove empty strings
+  if (keywords.length === 0) {
+    return text;
+  }
+
+  // Apply highlighting for each keyword sequentially
+  let highlightedText = text;
+  keywords.forEach(keyword => {
+    const regex = new RegExp(`(${escapeRegExp(keyword)})`, 'gi'); // 'g' for global, 'i' for case-insensitive
+    highlightedText = highlightedText.replace(regex, '<mark>$1</mark>');
+  });
+
+  return highlightedText;
+};
+
+export default function QuestionCard({ id, title, category, created_at, status, searchTerm }: QuestionCardProps) {
   const formattedDate = new Date(created_at).toLocaleDateString('ja-JP');
+  const displayTitle = highlightText(title, searchTerm);
+
   return (
     <Link href={`/question/${id}`} className="block p-4 border rounded-lg shadow hover:bg-gray-100 mb-4 transition-colors duration-150">
-      <h2 className="text-xl md:text-2xl font-semibold mb-2 break-words">{title}</h2>
+      {/* Use dangerouslySetInnerHTML for title because highlightText returns HTML string */}
+      <h2 className="text-xl md:text-2xl font-semibold mb-2 break-words" dangerouslySetInnerHTML={{ __html: displayTitle }} />
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center text-sm text-gray-600">
         <div className="mb-1 sm:mb-0">
           {category && (


### PR DESCRIPTION
メイン画面に質問を検索できる機能を追加しました。

主な変更点:
- 検索UI（テキストボックス、検索ボタン、クリアボタン）をメイン画面上部に配置
- 質問のタイトルと本文を対象とした部分一致検索（AND検索、大文字・小文字区別なし）
- 検索結果件数の表示と、0件の場合のメッセージ表示
- 検索キーワードのハイライト表示
- 既存のソート機能、ページネーション機能、カテゴリー絞り込み機能との連携

APIの変更:
- `/api/questions` エンドポイントに `search` クエリパラメータを追加し、キーワード検索に対応

フロントエンドの変更:
- `src/app/page.tsx`: 検索UIの追加と状態管理
- `src/components/QuestionList.tsx`: 検索キーワードの処理、API連携、結果表示
- `src/components/QuestionCard.tsx`: 検索キーワードのハイライト処理