### PR TITLE
feat: Implement Hepotama's Conclusion feature and fix runtime error

### DIFF
--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -39,7 +39,7 @@ const highlightText = (text: string | undefined, term: string | undefined) => {
   return highlightedText;
 };
 
-export default function QuestionCard({ id, title, category, created_at, status, searchTerm }: QuestionCardProps) {
+export default function QuestionCard({ id, title, category, created_at, status, searchTerm, admin_conclusion }: QuestionCardProps) {
   const formattedDate = new Date(created_at).toLocaleDateString('ja-JP');
   const displayTitle = highlightText(title, searchTerm);
   const hasAdminConclusion = admin_conclusion && admin_conclusion.trim() !== '';


### PR DESCRIPTION
This commit introduces the 'Hepotama's Conclusion' feature, allowing admins to add a special conclusion to questions, which is then viewable by you. It also includes a fix for a runtime error in QuestionCard.tsx.

Key changes include:

1.  **Database Schema:**
    *   Added `admin_conclusion` (TEXT) and `admin_conclusion_updated_at` (DateTime) to the `Question` model in `prisma/schema.prisma`. (Note: Migration needs to be run manually).

2.  **Admin API (`src/app/api/admin/questions/[id]/route.ts`):**
    *   Enhanced `GET` handler to return `admin_conclusion` and its update timestamp.
    *   Enhanced `PUT` handler to allow creating, updating, and clearing `admin_conclusion`, including input validation and timestamp management.

3.  **Admin Panel (`src/app/admin/question/[id]/page.tsx`):**
    *   Integrated a new 'Hepotama's Conclusion Management' section in the question editing page.
    *   Features a textarea for conclusion input (500-char limit, counter), save/clear buttons, and displays the last update time.
    *   Connects to the updated admin API for data operations.

4.  **Public API (`src/app/api/questions/[id]/route.ts` and `/api/questions/route.ts`):**
    *   Modified the single question API to include `admin_conclusion` and its timestamp.
    *   The multiple questions API already included these fields by default.

5.  **Public Question Page (`src/app/question/[id]/page.tsx`):**
    *   Displays a 'View Hepotama's Conclusion' button (styled with a Tama emoji) if a conclusion is present.
    *   Clicking the button opens a modal showing the conclusion title, content, formatted update timestamp, and close options, with a fade-in animation.

6.  **UX Enhancements (Visual Indicators):**
    *   '結論あり' (Conclusion Exists) badge now appears on question cards in the public list (`src/components/QuestionCard.tsx`) for questions with an admin conclusion.
    *   A similar badge appears in the admin question list (`src/components/AdminQuestionList.tsx`).

7.  **Bug Fix (`src/components/QuestionCard.tsx`):**
    *   Addressed a `ReferenceError: admin_conclusion is not defined` by correctly destructuring the `admin_conclusion` prop in the `QuestionCard` component signature. This ensures the '結論あり' badge functions correctly without runtime errors.

**Next Steps (Post-PR):**
*   Run Prisma migrations in the target environment.
*   Consider adding comprehensive unit and component tests for all new functionality in a follow-up.