### PR TITLE
feat: Implement Hepotama's Conclusion and address page loading issues

### DIFF
--- a/src/app/api/admin/questions/[id]/route.ts
+++ b/src/app/api/admin/questions/[id]/route.ts
@@ -34,7 +34,10 @@ export async function GET(request: NextRequest, { params }: RequestParams) {
         updated_at: true,
         admin_conclusion: true,
         admin_conclusion_updated_at: true,
-        // Include other fields if necessary, or select all non-sensitive fields
+        answers: true, // Include answers relation
+        // Optionally, include comments and _count for likes/nannoJikanDayoClicks if needed by admin page
+        // comments: true,
+        // _count: { select: { likes: true, nannoJikanDayoClicks: true } },
       },
     });
 

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -27,17 +27,31 @@ export async function GET(
         updated_at: true,
         admin_conclusion: true, // Added field
         admin_conclusion_updated_at: true, // Added field
-        // Include relations as before
-        answers: true,
+        answers: {
+          select: {
+            id: true,
+            content: true,
+            image_url: true,
+            link_url: true,
+            responder: true,
+            created_at: true,
+            updated_at: true, // Assuming this is also needed
+          }
+        },
         comments: {
-          orderBy: {
-            created_at: 'asc',
-          },
+          orderBy: { created_at: 'asc' },
+          select: {
+            id: true,
+            content: true,
+            commenter_name: true,
+            ip_address: true, // Be mindful of exposing IP if not necessary for public API
+            created_at: true,
+          }
         },
         _count: {
           select: {
             likes: true,
-            // nannoJikanDayoClicks: true, // Ensure this is commented if not needed
+            nannoJikanDayoClicks: true, // Ensure this is commented if not needed
           },
         },
       },


### PR DESCRIPTION
This commit includes the full 'Hepotama's Conclusion' feature, and addresses several issues related to data fetching for individual question pages (public and admin) and a runtime error in QuestionCard.

Feature: Hepotama's Conclusion
1.  Database Schema: Added `admin_conclusion` and `admin_conclusion_updated_at` to `Question` model.
2.  Admin API: `GET` and `PUT` handlers in `/api/admin/questions/[id]/route.ts` updated for conclusion management.
3.  Admin Panel: New section in `/admin/question/[id]/page.tsx` for managing conclusion text.
4.  Public API: `/api/questions/[id]/route.ts` updated to include conclusion data.
5.  Public Page: `/question/[id]/page.tsx` now displays a button to view the conclusion in a modal.
6.  UX: '結論あり' (Conclusion Exists) badges on public and admin question lists.

Bug Fixes & Refinements:
1.  `QuestionCard.tsx`: Fixed `ReferenceError: admin_conclusion is not defined` by correctly destructuring the prop.
2.  Admin API (`/api/admin/questions/[id]/route.ts`): Ensured the `GET` handler includes `answers` in its response, which is crucial for the admin edit page.
3.  Public API (`/api/questions/[id]/route.ts`):
    *   Consistently included `nannoJikanDayoClicks` in the `_count` select.
    *   Made the `select` clauses for `answers` and `comments` relations more explicit, detailing all fields to be returned from these related models. This aims to improve robustness of data fetching for the public question detail page.

These changes should improve the stability and functionality of the question detail and admin edit pages.